### PR TITLE
Potential fix for code scanning alert: Information exposure through an exception

### DIFF
--- a/src/api/v1/getCalendar.py
+++ b/src/api/v1/getCalendar.py
@@ -142,7 +142,7 @@ def handle_request(request: Request, args: dict, argv: dict):
             'Content-Disposition': 'attachment; filename=calendar.ics'
         }
 
-    except Exception as e:
+    except Exception:
         logging.error(traceback.format_exc())
         return jsonify({
             'error': 'An internal error has occurred!'

--- a/src/api/v1/getCalendar.py
+++ b/src/api/v1/getCalendar.py
@@ -2,6 +2,8 @@ from datetime import datetime, timedelta
 from flask import jsonify, Request
 from classes.calendar import Calendar, Events, Alarms
 from utils.getClass import get_simplified_classes, get_detailed_classes
+import traceback
+import logging
 
 def handle_request(request: Request, args: dict, argv: dict):
     """
@@ -141,6 +143,7 @@ def handle_request(request: Request, args: dict, argv: dict):
         }
 
     except Exception as e:
+        logging.error(traceback.format_exc())
         return jsonify({
-            'error': str(e)
+            'error': 'An internal error has occurred!'
         }), 500 

--- a/src/api/v1/getLessons.py
+++ b/src/api/v1/getLessons.py
@@ -90,4 +90,4 @@ def handle_request(request: Request, args: dict, argv: dict):
         
     except Exception as e:
         app.logger.error(f"Error getting lessons info: {str(e)}")
-        return jsonify({'error': str(e)}), 500 
+        return jsonify({'error': 'An internal error has occurred!'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/thnhmai06/vnu-auto-scheduler/security/code-scanning/6](https://github.com/thnhmai06/vnu-auto-scheduler/security/code-scanning/6)

To fix the problem, we need to modify the exception handling in the `handle_request` function to ensure that detailed error messages are logged on the server, while a generic error message is returned to the user. This involves:
1. Logging the detailed error message using the application's logger.
2. Returning a generic error message in the JSON response to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
